### PR TITLE
Fix now(tz)

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -385,7 +385,7 @@ class FakeDatetime(real_datetime, FakeDate, metaclass=FakeDatetimeMeta):
     def now(cls, tz=None):
         now = cls._time_to_freeze() or real_datetime.now()
         if tz:
-            result = tz.fromutc(now.replace(tzinfo=tz)) + cls._tz_offset()
+            result = tz.fromutc(now.replace(tzinfo=tz))
         else:
             result = now + cls._tz_offset()
         return datetime_to_fakedatetime(result)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -66,7 +66,7 @@ def test_datetime_timezone_real():
 @freeze_time("2012-01-14 2:00:00", tz_offset=-4)
 def test_datetime_timezone_real_with_offset():
     now = datetime.datetime.now(tz=GMT5())
-    assert now == datetime.datetime(2012, 1, 14, 3, tzinfo=GMT5())
+    assert now == datetime.datetime(2012, 1, 14, 7, tzinfo=GMT5())
     assert now.utcoffset() == timedelta(0, 60 * 60 * 5)
 
 


### PR DESCRIPTION
now(tz) should return the same time utcnow returns adjusted by whatever offset is contained by tz. Currently, the offset to freeze_time is also added, which is removed by this change

The current unit test is wrong because the UTC time is 2:00:00, so GMT5 should be 7:00:00, not 3:00:00

Closes https://github.com/spulec/freezegun/issues/405